### PR TITLE
use FnMut instead of Fn for search comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Is implemented for `RangeInclusive<T>`, specifying the range of search. Its bina
 /// Using a closure `cmpr` to sample and compare data to captured target.
 pub trait Search<T> {
     /// Unchecked  Ok(first hit) or Err(insert order of a missing item).
-    fn binary_by(self, cmpr: impl Fn(T) -> Ordering) -> Result <T,T>;
+    fn binary_by(self, cmpr: impl FnMut(T) -> Ordering) -> Result <T,T>;
     /// Unchecked first hit or insert order, and the final search range.
-    fn binary_any(&self, cmpr: impl Fn(T) -> Ordering) -> (T, Range<T>);
+    fn binary_any(&self, cmpr: impl FnMut(T) -> Ordering) -> (T, Range<T>);
     /// General Binary Search, returns the range of all matching items
-    fn binary_all(&self, cmpr: impl Fn(T)-> Ordering) -> Range<T>;
+    fn binary_all(&self, cmpr: impl FnMut(T)-> Ordering) -> Range<T>;
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,11 @@ where
 /// Using a closure `cmpr` to sample and compare data to captured target.
 pub trait Search<T> {
     /// Unchecked first Ok(hit) or Err(insert order for a missing item).
-    fn binary_by(self, cmpr: impl Fn(T) -> Ordering) -> Result<T, T>;
+    fn binary_by(self, cmpr: impl FnMut(T) -> Ordering) -> Result<T, T>;
     /// Unchecked first hit or insert order, and the final search range.
-    fn binary_any(&self, cmpr: impl Fn(T) -> Ordering) -> (T, Range<T>);
+    fn binary_any(&self, cmpr: impl FnMut(T) -> Ordering) -> (T, Range<T>);
     /// General Binary Search, returns the range of all matching items
-    fn binary_all(&self, cmpr: impl Fn(T) -> Ordering) -> Range<T>;
+    fn binary_all(&self, cmpr: impl FnMut(T) -> Ordering) -> Range<T>;
 }
 
 /// Methods to manipulate indices of `Vec<usize>` type.


### PR DESCRIPTION
This fixes #2. There does not seem to be a notable effect on benchmark results.